### PR TITLE
Fixed conversion of xmlPCDATA for <argument> (fixes issue #203)

### DIFF
--- a/src/simpleserver/config/xml/Argument.java
+++ b/src/simpleserver/config/xml/Argument.java
@@ -34,8 +34,8 @@ class Argument extends XMLTag {
   void setAttribute(String name, String value) throws SAXException {
     if (name.equals("allow")) {
       allow = new Permission(value);
-    } else if (name.equals("value")) {
-      argument = value;
+    } else if (name.equals("name")) {
+      content(value);
     }
   }
 


### PR DESCRIPTION
I'm sending this bugfix as a pull request so that the other contributors can review and test the code. You can test these changes by trying different combinations of "true" and "false" for xmlPCDATA and xmlInlineAttributes. These are the proper forms of the &lt;argument&gt; tag:
- xmlPCDATA = true

``` xml
<argument allow="4+">*</argument>
```
- xmlPCDATA = false

``` xml
<argument name="*" allow="4+"/>
```
