### PR TITLE
Add MagicLauncher-like functionality

### DIFF
--- a/src/simpleserver/options/defaults/simpleserver.properties
+++ b/src/simpleserver/options/defaults/simpleserver.properties
@@ -8,6 +8,7 @@ enableRcon=false
 enableTelnet=false
 enableEvents=false
 enableCustAuthExport=false
+enablePlugins=false
 gameMode=0
 generateStructures=true
 internalPort=25566


### PR DESCRIPTION
This allows loading alternate class files from mod zip files in the same way as MagicLauncher, without needing to actually change the server jar file. It sets up the class path on the java command line, which tells java to load a class from an alternate file, instead of from the normal jar. The plugins go into a plugins directory, and an option allows specifying whether to do this at all, or just use the normal no-mod-loading behavior. The mods have precedence according to their alphabetical order in the directory, so a prefix like 01_, 02_, etc is convenient to choose loading order.

I would love any feedback about this feature, about whether it seems like a good idea or not, and whether my implementation is any good. Thanks.
