### PR TITLE
Fix for data longer than 255 bytes for 0x83 packet

### DIFF
--- a/src/simpleserver/stream/StreamTunnel.java
+++ b/src/simpleserver/stream/StreamTunnel.java
@@ -920,7 +920,7 @@ public class StreamTunnel {
         write(in.readShort());
         short length = in.readShort();
         write(length);
-        copyNBytes(0xff & length);
+        copyNBytes(length);
         break;
       case (byte) 0x84: // added in 12w06a
         write(packetId);


### PR DESCRIPTION
Seems like forgotten 0xff in copy operation limiting length of data.
