### PR TITLE
Update Bot.java

### DIFF
--- a/src/simpleserver/bot/Bot.java
+++ b/src/simpleserver/bot/Bot.java
@@ -746,7 +746,7 @@ public class Bot {
   protected void error(String reason) {
     die();
     if (!expectDisconnect) {
-      print("Bot " + name + " died (" + reason + ")");
+      print("Bot " + name + " died (" + reason + ")\n");
     }
   }
 
@@ -769,11 +769,11 @@ public class Bot {
             try {
               connect();
             } catch (Exception e2) {
-              error("Soket closed on reconnect");
+              error("Socket closed on reconnect");
             }
             break;
           } else {
-            error("Soket closed");
+            error("Socket closed");
           }
         }
       }


### PR DESCRIPTION
3 total edits. The first fixes a minor glitch when SimpleServer prints "Bot Teleporter\* died (<reason>)" but doesn't print a newline. The other two are spelling fixes: "Soket" -> "Socket"
