### PR TITLE
Add dedicated events log file support

### DIFF
--- a/src/simpleserver/Server.java
+++ b/src/simpleserver/Server.java
@@ -62,6 +62,7 @@ import simpleserver.log.AdminLog;
 import simpleserver.log.ConnectionLog;
 import simpleserver.log.ErrorLog;
 import simpleserver.log.MessageLog;
+import simpleserver.log.EventsLog;
 import simpleserver.message.Chat;
 import simpleserver.message.Messager;
 import simpleserver.minecraft.MinecraftWrapper;
@@ -114,6 +115,7 @@ public class Server {
   private ErrorLog errorLog;
   private ConnectionLog connectionLog;
   private MessageLog messageLog;
+  private EventsLog eventsLog;
   private SystemInputQueue systemInput;
 
   public CustAuthExport custAuthExport;
@@ -465,6 +467,10 @@ public class Server {
   public void errorLog(Exception exception, String message) {
     errorLog.addMessage(exception, message);
   }
+  
+  public void eventsLog(String event, String message) {
+    eventsLog.addMessage(event,message);
+  }
 
   public void connectionLog(String type, Socket socket, String comments) {
     connectionLog.addMessage(type, socket, comments);
@@ -547,6 +553,7 @@ public class Server {
     adminLog = new AdminLog();
     errorLog = new ErrorLog();
     connectionLog = new ConnectionLog();
+  eventsLog = new EventsLog();
 
     commandParser = new CommandParser(options);
   }
@@ -556,6 +563,7 @@ public class Server {
     adminLog.stop();
     errorLog.stop();
     connectionLog.stop();
+	eventsLog.stop();
     messageLog.stop();
     time.unfreeze();
     bots.cleanup();

--- a/src/simpleserver/events/RunningEvent.java
+++ b/src/simpleserver/events/RunningEvent.java
@@ -35,6 +35,8 @@ import simpleserver.command.ServerCommand;
 import simpleserver.config.xml.CommandConfig;
 import simpleserver.config.xml.CommandConfig.Forwarding;
 import simpleserver.config.xml.Event;
+import simpleserver.log.EventsLog;
+
 
 class RunningEvent extends Thread implements Runnable {
 
@@ -137,7 +139,14 @@ class RunningEvent extends Thread implements Runnable {
         continue;
       } else if (cmd.equals("print") && tokens.size() > 0) {
         System.out.println("L" + String.valueOf(currline) + "@" + event.name + " msg: " + tokens.get(0));
-      } else if (cmd.equals("sleep") && tokens.size() > 0) {
+      } 
+      else if (cmd.equals("log") && tokens.size() >  0){
+		server.eventsLog(event.name + " @L" + String.valueOf(currline),tokens.get(0));
+	  }
+	    else if (cmd.equals("logprint") && tokens.size() > 0){
+		server.eventsLog(event.name + " @L" + String.valueOf(currline),tokens.get(0));
+        System.out.println("L" + String.valueOf(currline) + "@" + event.name + " msg: " + tokens.get(0));		
+	  } else if (cmd.equals("sleep") && tokens.size() > 0) {
         try {
           Thread.sleep(Integer.valueOf(tokens.get(0)));
         } catch (InterruptedException e) {

--- a/src/simpleserver/log/EventsLog.java
+++ b/src/simpleserver/log/EventsLog.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2013 SimpleServer authors (see CONTRIBUTORS)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package simpleserver.log;
+
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
+
+public class EventsLog extends AbstractLog {
+  public EventsLog() {
+    super("events");
+  }
+
+  public void addMessage(String event, String message) {
+    CharArrayWriter charWriter = new CharArrayWriter();
+    PrintWriter writer = new PrintWriter(charWriter);
+  
+	writer.append(event + "\t" + message);
+    super.addMessage(charWriter.toString());
+
+    writer.close();
+    charWriter.close();
+  }
+}


### PR DESCRIPTION
I've created some code that allows events in SimpleServer to write to a separate log file.

Events can use the commands "log" and "logprint". The command "log" will output log text only to the file, and "logprint" will output data to the file and console simultaneously.

Example:

``` xml
<event name="TestEvent">
log "Test log command"
logprint "Test logprint command"
</event>
```

Output:

File created: events_20130528-221831.txt

```
2013-05-28 22:18:34 TestEvent @L1   Test log command
2013-05-28 22:18:34 TestEvent @L2   Test logprint command
```

Console:

```
L2@TestEvent msg: Test logprint command
```
