### PR TITLE
fixes #297

### DIFF
--- a/src/simpleserver/bot/BotController.java
+++ b/src/simpleserver/bot/BotController.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.apache.commons.lang.StringUtils;
 import simpleserver.Server;
 
 public class BotController {
@@ -116,6 +117,12 @@ public class BotController {
   }
 
   public boolean ninja(String name) {
+
+    // hacky fix to translate §eTeleporter50983§e
+    // to Teleporter50983
+    name = name.replaceAll("[^A-Za-z0-9]", "");
+    name = StringUtils.removeEnd(name, "e");
+
     Bot bot = bots.get(name);
     if (bot == null) {
       return deadNinjas.contains(name);

--- a/src/simpleserver/bot/Teleporter.java
+++ b/src/simpleserver/bot/Teleporter.java
@@ -50,6 +50,7 @@ public class Teleporter extends Bot {
   protected void prepare() throws IOException {
     dat = new PlayerFile(name, server);
     dat.setPosition(position);
+    server.bots.ninja(name);
     dat.save();
   }
 

--- a/src/simpleserver/stream/StreamTunnel.java
+++ b/src/simpleserver/stream/StreamTunnel.java
@@ -56,7 +56,7 @@ public class StreamTunnel {
   private static final byte BLOCK_DESTROYED_STATUS = 2;
   private static final Pattern MESSAGE_PATTERN = Pattern.compile("^<([^>]+)> (.*)$");
   private static final Pattern COLOR_PATTERN = Pattern.compile("\u00a7[0-9a-z]");
-  private static final Pattern JOIN_PATTERN = Pattern.compile("\u00a7.((\\d|\\w)*) (joined|left) the game.");
+  private static final Pattern JOIN_PATTERN = Pattern.compile("\u00a7.((\\d|\\w|\\u00a7)*) (joined|left) the game.");
   private static final String CONSOLE_CHAT_PATTERN = "\\[Server:.*\\]";
   private static final int MESSAGE_SIZE = 60;
   private static final int MAXIMUM_MESSAGE_SIZE = 119;


### PR DESCRIPTION
Probably not the best fix on the block, but here is the deal.

```
§eTeleporter66089 left the game.
§eTeleporter50983§e joined the game.
```

See the difference? That is why it would show all the time, since it would fail the REGEX check. However, my skills with regex are beyond pathetic. There is probably a way to write regex to ignore that secondary unicode char, without adding as much code as I did.

My method just looks for either NULL or unicode char, then removes all non-printable char and removes the "e" from the end, thus getting the raw name of the teleporter. Which then falls into the Set which passes the check.
