### PR TITLE
Minecraft 1.6.4 updates

### DIFF
--- a/src/simpleserver/Main.java
+++ b/src/simpleserver/Main.java
@@ -33,8 +33,8 @@ public class Main {
   private static final String baseVersion = "8.4.10";
   private static final boolean release = false;
   private static final String releaseState = "release";
-  public static final int protocolVersion = 74;
-  public static final String minecraftVersion = "1.6.2";
+  public static final int protocolVersion = 78;
+  public static final String minecraftVersion = "1.6.4";
   public static final String version;
 
   static {


### PR DESCRIPTION
Updating SS to support 1.6.4 clients. It appears that the only change between 1.6.2 and 1.6.4 in terms of the protocol is simply the version number.
